### PR TITLE
Inject Spring environment to get access to project properties file

### DIFF
--- a/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
+++ b/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
@@ -15,6 +15,7 @@ import org.opensaml.xml.parse.StaticBasicParserPool;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -70,6 +71,8 @@ import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuc
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 import java.util.Timer;
 
 /**
@@ -77,6 +80,9 @@ import java.util.Timer;
  * This class should be extended by Sp's Java-based Spring configuration for web security.
  */
 public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+
+    @Inject
+    protected Environment env;
 
     @Autowired
     private SAMLAuthenticationProvider samlAuthenticationProvider;
@@ -297,7 +303,7 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
     }
 
     // Configure TLSProtocolConfigurer
-    @Bean
+    @PostConstruct
     public MethodInvokingFactoryBean socketFactoryInitialization() {
         MethodInvokingFactoryBean methodInvokingFactoryBean = new MethodInvokingFactoryBean();
         methodInvokingFactoryBean.setTargetClass(Protocol.class);


### PR DESCRIPTION
I was unable to inject the Spring environment in the child class (injection is done too late, after  samlConfigBean() method is called resulting in a nullpointer). I also switched the method `MethodInvokingFactoryBean socketFactoryInitialization()` annoation from @bean to **@PostConstruct** (@Bean was executing the method before Spring had a chance to inject the environment, resulting to a nullpointer in  `samlConfigBean()`  method).

Usage of Spring environment in the Child class:

```
    @Override
    protected SAMLConfigBean samlConfigBean() {
        return new SAMLConfigBeanBuilder()
            .setIdpServerName(env.getProperty("idm.idpServerName"))
            .setSpServerName(env.getProperty("spServerName"))
            .setSpHttpsPort(Integer.parseInt(env.getProperty("idm.spHttpsPort")))
            .setSpContextPath(null)
            .setKeystoreResource(new DefaultResourceLoader().getResource(env.getProperty("idm.keystore.path")))
            .setKeystoreAlias(env.getProperty("idm.keystore.alias"))
            .setKeystorePassword(env.getProperty("idm.keystore.password"))
            .setKeystorePrivateKeyPassword(env.getProperty("idm.keystore.privateKeyPassword"))
            .setSuccessLoginDefaultUrl("/login")
            .setSuccessLogoutUrl("/logout")
            .createSAMLConfigBean();
    }
```
