### PR TITLE
Proper fix this time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>spring-security-adfs-saml2</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
     <packaging>jar</packaging>
 
     <name>Spring Security ADFS SAML2</name>

--- a/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
+++ b/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
@@ -86,15 +86,11 @@ import java.util.Timer;
  * This class should be extended by Sp's Java-based Spring configuration for web security.
  */
 public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
-
     /**
      * Provides an opportunity for child class to access Spring environment, if needed.
      */
     @Autowired
     protected Environment env;
-
-    @Autowired
-    private SAMLAuthenticationProvider samlAuthenticationProvider;
 
     // Initialization of OpenSAML library, must be static to prevent "ObjectPostProcessor is a required bean" exception
     // By default, Spring Security SAML uses SHA-1. So, use `DefaultSAMLBootstrap` to use SHA-256.

--- a/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
+++ b/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
@@ -92,6 +92,8 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
     @Autowired
     protected Environment env;
 
+    private SAMLAuthenticationProvider cachedSamlAuthenticationProvider;
+
     // Initialization of OpenSAML library, must be static to prevent "ObjectPostProcessor is a required bean" exception
     // By default, Spring Security SAML uses SHA-1. So, use `DefaultSAMLBootstrap` to use SHA-256.
     @Bean
@@ -311,7 +313,7 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
     // Register authentication manager for SAML provider
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.authenticationProvider(samlAuthenticationProvider);
+        auth.authenticationProvider(samlAuthenticationProvider());
     }
 
     // Logger for SAML messages and events
@@ -388,6 +390,9 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
     // SAML Authentication Provider responsible for validating of received SAML messages
     @Bean
     public SAMLAuthenticationProvider samlAuthenticationProvider() {
+        if (cachedSamlAuthenticationProvider != null) {
+            return cachedSamlAuthenticationProvider;
+        }
         SAMLAuthenticationProvider samlAuthenticationProvider = new SAMLAuthenticationProvider();
         SAMLUserDetailsService samlUserDetailsService = samlConfigBean().getSamlUserDetailsService();
 
@@ -401,6 +406,7 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
             samlAuthenticationProvider.setForcePrincipalAsString(false);
         }
 
+        cachedSamlAuthenticationProvider = samlAuthenticationProvider;
         return samlAuthenticationProvider;
     }
 

--- a/src/test/groovy/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapterSpec.groovy
+++ b/src/test/groovy/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapterSpec.groovy
@@ -132,6 +132,27 @@ class SAMLWebSecurityConfigurerAdapterSpec extends Specification {
         samlUserDetailsService       | false
     }
 
+    def "authenticationProvider caches the result, returns same one on multiple calls"() {
+        given:
+        SAMLUserDetailsService userDetailsService = samlUserDetailsService
+
+        when:
+        def adapter = new SAMLWebSecurityConfigurerAdapter() {
+            @Override
+            protected SAMLConfigBean samlConfigBean() {
+                return allFieldsBeanBuilder.
+                        withSamlUserDetailsService(userDetailsService).
+                        build()
+            }
+        }
+
+        def provider1 = adapter.samlAuthenticationProvider()
+        def provider2 = adapter.samlAuthenticationProvider()
+
+        then:
+        provider1 == provider2
+    }
+
     def "mockSecurity - given null user, should throw exception"() {
         given:
         def http = new HttpSecurity(Mock(ObjectPostProcessor), Mock(AuthenticationManagerBuilder), [:] as Map)


### PR DESCRIPTION
The bean creation is now cached and autowiring is not done - the method is called directly instead.

This allows for the whole bean to be uninitialized before PostConstruct, yet it does not crash because no methods are being called during construction.