### PR TITLE
Update SAMLWebSecurityConfigurerAdapter.java

### DIFF
--- a/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
+++ b/src/main/java/com/github/choonchernlim/security/adfs/saml2/SAMLWebSecurityConfigurerAdapter.java
@@ -347,7 +347,7 @@ public abstract class SAMLWebSecurityConfigurerAdapter extends WebSecurityConfig
 
     // Configure HTTP Client to accept certificates from the keystore instead of JDK keystore  for HTTPS verification
     @Bean
-    public TLSProtocolConfigurer tlsProtocolConfigurer() {
+    protected TLSProtocolConfigurer tlsProtocolConfigurer() {
         return new TLSProtocolConfigurer();
     }
 


### PR DESCRIPTION
Made tlsProtocolConfigurer protected so that a client can disable it to rely on installed JDK's truststore.